### PR TITLE
Match flash fiddly bits

### DIFF
--- a/format/swf/Data.hx
+++ b/format/swf/Data.hx
@@ -205,8 +205,6 @@ typedef Shape4Data = {
 
 // used by DefineFont
 typedef ShapeWithoutStyleData = {
-	var fillBits: Int;
-	var lineBits: Int;
 	var shapeRecords : Array<ShapeRecord>;
 }
 
@@ -214,8 +212,6 @@ typedef ShapeWithoutStyleData = {
 typedef ShapeWithStyleData = {
 	var fillStyles : Array<FillStyle>;
 	var lineStyles : Array<LineStyle>;
-	var fillBits: Int;
-	var lineBits: Int;
 	var shapeRecords : Array<ShapeRecord>;
 }
 
@@ -246,8 +242,6 @@ typedef SCRIndex = {
 typedef SCRNewStyles = {
 	var fillStyles : Array<FillStyle>;
 	var lineStyles : Array<LineStyle>;
-	var fillBits: Int;
-	var lineBits: Int;
 }
 
 enum FillStyle {

--- a/format/swf/Data.hx
+++ b/format/swf/Data.hx
@@ -205,6 +205,8 @@ typedef Shape4Data = {
 
 // used by DefineFont
 typedef ShapeWithoutStyleData = {
+	var fillBits: Int;
+	var lineBits: Int;
 	var shapeRecords : Array<ShapeRecord>;
 }
 
@@ -212,6 +214,8 @@ typedef ShapeWithoutStyleData = {
 typedef ShapeWithStyleData = {
 	var fillStyles : Array<FillStyle>;
 	var lineStyles : Array<LineStyle>;
+	var fillBits: Int;
+	var lineBits: Int;
 	var shapeRecords : Array<ShapeRecord>;
 }
 
@@ -242,6 +246,8 @@ typedef SCRIndex = {
 typedef SCRNewStyles = {
 	var fillStyles : Array<FillStyle>;
 	var lineStyles : Array<LineStyle>;
+	var fillBits: Int;
+	var lineBits: Int;
 }
 
 enum FillStyle {

--- a/format/swf/Reader.hx
+++ b/format/swf/Reader.hx
@@ -340,8 +340,6 @@ class Reader {
 		return {
 			fillStyles: fillStyles,
 			lineStyles: lineStyles,
-			fillBits: fillBits,
-			lineBits: lineBits,
 			shapeRecords: readShapeRecords(ver, fillBits, lineBits)
 		};
 	}
@@ -351,8 +349,6 @@ class Reader {
 		var fillBits = bits.readBits(4);
 		var lineBits = bits.readBits(4);
 		return {
-			fillBits: fillBits,
-			lineBits: lineBits,
 			shapeRecords: readShapeRecords(ver, fillBits, lineBits)
 		};
 	}
@@ -443,8 +439,6 @@ class Reader {
 						cdata.newStyles = {
 							fillStyles: fst,
 							lineStyles: lst,
-							fillBits: fillBits,
-							lineBits: lineBits
 						}
 					}
 					recs.push(SHRChange(cdata));

--- a/format/swf/Reader.hx
+++ b/format/swf/Reader.hx
@@ -1344,18 +1344,18 @@ class Reader {
 			null;
 		case TagId.ShowFrame:
 			TShowFrame;
-		case TagId.DefineShape:
-			readShape(len,1);
-		case TagId.DefineShape2:
-			readShape(len,2);
-		case TagId.DefineShape3:
-			readShape(len,3);
-		case TagId.DefineShape4:
-			readShape(len,4);
-		case TagId.DefineMorphShape:
-			readMorphShape(1);
-		case TagId.DefineMorphShape2:
-			readMorphShape(2);
+		//case TagId.DefineShape:
+		//	readShape(len,1);
+		//case TagId.DefineShape2:
+		//	readShape(len,2);
+		//case TagId.DefineShape3:
+		//	readShape(len,3);
+		//case TagId.DefineShape4:
+		//	readShape(len,4);
+		//case TagId.DefineMorphShape:
+		//	readMorphShape(1);
+		//case TagId.DefineMorphShape2:
+		//	readMorphShape(2);
 		
 		case TagId.DefineFont:
 			readFont(len, 1);

--- a/format/swf/Reader.hx
+++ b/format/swf/Reader.hx
@@ -849,7 +849,7 @@ class Reader {
 		var endBounds = readRect();
 		switch(ver) {
 			case 1:
-				readInt(); // ?
+				var offsetToEndEdges = readInt();
 				var fillStyles = readMorphFillStyles(ver);
 				var lineStyles = readMorph1LineStyles();
 				var startEdges = readShapeWithoutStyle(3); // Assume DefineShape3

--- a/format/swf/Reader.hx
+++ b/format/swf/Reader.hx
@@ -652,6 +652,7 @@ class Reader {
 
 		var shapeBounds = readRect();
 		var edgeBounds = readRect();
+		bits.reset();
 		bits.readBits(5);
 		var useWinding = bits.readBit();
 		var useNonScalingStroke = bits.readBit();

--- a/format/swf/Reader.hx
+++ b/format/swf/Reader.hx
@@ -334,16 +334,26 @@ class Reader {
 	function readShapeWithStyle(ver : Int) : ShapeWithStyleData {
 		var fillStyles = readFillStyles(ver);
 		var lineStyles = readLineStyles(ver);
+		bits.reset();
+		var fillBits = bits.readBits(4);
+		var lineBits = bits.readBits(4);
 		return {
 			fillStyles: fillStyles,
 			lineStyles: lineStyles,
-			shapeRecords: readShapeRecords(ver)
+			fillBits: fillBits,
+			lineBits: lineBits,
+			shapeRecords: readShapeRecords(ver, fillBits, lineBits)
 		};
 	}
 	
 	function readShapeWithoutStyle(ver : Int) : ShapeWithoutStyleData {
+		bits.reset();
+		var fillBits = bits.readBits(4);
+		var lineBits = bits.readBits(4);
 		return {
-			shapeRecords: readShapeRecords(ver)
+			fillBits: fillBits,
+			lineBits: lineBits,
+			shapeRecords: readShapeRecords(ver, fillBits, lineBits)
 		};
 	}
 
@@ -351,11 +361,7 @@ class Reader {
 	//
 	// reads a SHAPE field
 	//
-	function readShapeRecords(ver : Int) : Array<ShapeRecord> {
-		bits.reset();
-		var fillBits = bits.readBits(4);
-		var lineBits = bits.readBits(4);
-
+	function readShapeRecords(ver : Int, fillBits: Int, lineBits: Int) : Array<ShapeRecord> {
 		var recs = new Array<ShapeRecord>();
 
 		do {
@@ -436,7 +442,9 @@ class Reader {
 						lineBits = bits.readBits(4);
 						cdata.newStyles = {
 							fillStyles: fst,
-							lineStyles: lst
+							lineStyles: lst,
+							fillBits: fillBits,
+							lineBits: lineBits
 						}
 					}
 					recs.push(SHRChange(cdata));
@@ -854,7 +862,6 @@ class Reader {
 				var fillStyles = readMorphFillStyles(ver);
 				var lineStyles = readMorph1LineStyles();
 				var startEdges = readShapeWithoutStyle(3); // Assume DefineShape3
-				bits.reset();
 				var endEdges = readShapeWithoutStyle(3);
 
 				return TMorphShape(id, MSDShape1({
@@ -874,7 +881,7 @@ class Reader {
 				var useNonScalingStrokes = bits.readBit();
 				var useScalingStrokes = bits.readBit();
 				bits.reset();
-				readInt(); // ?
+				readInt(); // Offset to EndEdges.
 				var fillStyles = readMorphFillStyles(ver);
 				var lineStyles = readMorph2LineStyles();
 				var startEdges = readShapeWithoutStyle(4); // Assume DefineShape4

--- a/format/swf/Tools.hx
+++ b/format/swf/Tools.hx
@@ -97,6 +97,14 @@ class Tools {
 		return x;
 	}
 
+	public static function signedMinBits(values: Array<Int>): Int {
+		var x: Int = minBits(values);
+		if (x != 0) {
+			x += 1;
+		}
+		return x;
+	}
+
 	public static function hex( b : haxe.io.Bytes, ?max : Int ) {
 		var hex = ["0".code,"1".code,"2".code,"3".code,"4".code,"5".code,"6".code,"7".code,"8".code,"9".code,"A".code,"B".code,"C".code,"D".code,"E".code,"F".code];
 		var count = if( max == null || b.length <= max ) b.length else max;

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -60,23 +60,9 @@ class Writer {
 		writeEnd();
 	}
 
-	function signedMinBits(values: Array<Int>): Int {
-		var x: Int = 0;
-		var allZeroes = true;
-		for (v in values) {
-			if (v != 0) {
-				allZeroes = false;
-				break;
-			}
-		}
-		if (! allZeroes) {
-			x = Tools.minBits(values) + 1;
-		}
-		return x;
-	}
 
 	function writeRect(r) {
-		var nbits = signedMinBits([r.left, r.right, r.top, r.bottom]);
+		var nbits = Tools.signedMinBits([r.left, r.right, r.top, r.bottom]);
 
 		bits.writeBits(5,nbits);
 		bits.writeBits(nbits,r.left);
@@ -165,7 +151,7 @@ class Writer {
 
 			var rs0 = Tools.toFixed16(m.rotate.rs0);
 			var rs1 = Tools.toFixed16(m.rotate.rs1);
-			var nbits = signedMinBits([rs0, rs1]);
+			var nbits = Tools.signedMinBits([rs0, rs1]);
 
 			bits.writeBits(5, nbits);
 			bits.writeBits(nbits, rs0);
@@ -174,7 +160,7 @@ class Writer {
 		} else
 			bits.writeBit(false);
 
-		var nbits = signedMinBits([m.translate.x, m.translate.y]);
+		var nbits = Tools.signedMinBits([m.translate.x, m.translate.y]);
 
 		bits.writeBits(5, nbits);
 		bits.writeBits(nbits, m.translate.x);

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -870,6 +870,7 @@ class Writer {
 		if(num < 1 || num > 8)
 			throw "Number of specified morph gradients ("+num+") must be in range 1..8";
 
+		o.writeByte(num);
 		for(grad in gradients) {
 			writeMorphGradient(ver, grad);
 		}

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -518,8 +518,8 @@ class Writer {
 	}
 
 	function writeFocalGradient(ver: Int, grad: FocalGradient) {
-		if(ver < 4)
-			throw "Focal gradient only supported in shape versions higher than 3!";
+		//if(ver < 4)
+		//	throw "Focal gradient only supported in shape versions higher than 3!";
 
 		writeGradient(ver, grad.data);
 		writeFixed8(grad.focalPoint);
@@ -552,8 +552,8 @@ class Writer {
 				writeGradient(ver, grad);
 
 			case FSFocalGradient(mat, grad):
-				if(ver < 3)
-					throw "Focal gradient fill style only supported with Shape versions higher than 3!";
+				//if(ver < 3)
+				//	throw "Focal gradient fill style only supported with Shape versions higher than 3!";
 
 				o.writeByte(FillStyleTypeId.FocalRadialGradient);
 				writeMatrix(mat);

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -788,9 +788,9 @@ class Writer {
 	function writeShapeWithoutStyle(ver: Int, data: ShapeWithoutStyleData) {
 		var style_info: ShapeStyleInfo = {
 			numFillStyles: 0,
-			fillBits: 1,
+			fillBits: data.fillBits,
 			numLineStyles: 0,
-			lineBits: 1
+			lineBits: data.lineBits
 		};
 
 		bits.writeBits(4, style_info.fillBits);

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -36,9 +36,7 @@ import format.swf.Constants;
  *	and the minimum number of bits required for indexing.
 */
 typedef ShapeStyleInfo = {
-	var numFillStyles: Int;
 	var fillBits: Int;
-	var numLineStyles: Int;
 	var lineBits: Int;
 }
 
@@ -722,10 +720,8 @@ class Writer {
 					writeFillStyles(ver, data.newStyles.fillStyles);
 					writeLineStyles(ver, data.newStyles.lineStyles);
 
-					style_info.numFillStyles = data.newStyles.fillStyles.length;
-					style_info.numLineStyles = data.newStyles.lineStyles.length;
-					style_info.fillBits = Tools.minBits([style_info.numFillStyles]);
-					style_info.lineBits = Tools.minBits([style_info.numLineStyles]);
+					style_info.fillBits = Tools.minBits([data.newStyles.fillStyles.length]);
+					style_info.lineBits = Tools.minBits([data.newStyles.lineStyles.length]);
 
 					bits.writeBits(4, style_info.fillBits);
 					bits.writeBits(4, style_info.lineBits);
@@ -771,12 +767,10 @@ class Writer {
 		}
 	}
 
-	function writeShapeWithoutStyle(ver: Int, data: ShapeWithoutStyleData) {
+	function writeShapeWithoutStyle(ver: Int, data: ShapeWithoutStyleData, numFillStyles: Int, numLineStyles: Int) {
 		var style_info: ShapeStyleInfo = {
-			numFillStyles: 0,
-			fillBits: data.fillBits,
-			numLineStyles: 0,
-			lineBits: data.lineBits
+			fillBits: Tools.minBits([numFillStyles]),
+			lineBits: Tools.minBits([numLineStyles]),
 		};
 
 		bits.writeBits(4, style_info.fillBits);
@@ -794,9 +788,7 @@ class Writer {
 		writeLineStyles(ver, data.lineStyles);
 
 		var style_info: ShapeStyleInfo = {
-			numFillStyles: data.fillStyles.length,
 			fillBits: Tools.minBits([data.fillStyles.length]),
-			numLineStyles: data.lineStyles.length,
 			lineBits: Tools.minBits([data.lineStyles.length]),
 		};
 
@@ -1042,14 +1034,14 @@ class Writer {
 
 				writeMorphFillStyles(1, sh1data.fillStyles);
 				writeMorph1LineStyles(sh1data.lineStyles);
-				writeShapeWithoutStyle(3, sh1data.startEdges);
+				writeShapeWithoutStyle(3, sh1data.startEdges, sh1data.fillStyles.length, sh1data.lineStyles.length);
 				bits.flush();
 
 				var part_data = closeTMP(old);
 
 				writeInt(part_data.length);
 				o.write(part_data);
-				writeShapeWithoutStyle(3, sh1data.endEdges);
+				writeShapeWithoutStyle(3, sh1data.endEdges, 0, 0);
 
 			case MSDShape2(sh2data):
 				writeRect(sh2data.startBounds);
@@ -1065,14 +1057,14 @@ class Writer {
 
 				writeMorphFillStyles(1, sh2data.fillStyles);
 				writeMorph2LineStyles(sh2data.lineStyles);
-				writeShapeWithoutStyle(4, sh2data.startEdges);
+				writeShapeWithoutStyle(4, sh2data.startEdges, sh2data.fillStyles.length, sh2data.lineStyles.length);
 				bits.flush();
 
 				var part_data = closeTMP(old);
 
 				writeInt(part_data.length);
 				o.write(part_data);
-				writeShapeWithoutStyle(4, sh2data.endEdges);
+				writeShapeWithoutStyle(4, sh2data.endEdges, 0, 0);
 		}
 
 		bits.flush();
@@ -1100,7 +1092,7 @@ class Writer {
 			offsets.push(offs);
 
 			var old = openTMP();
-			writeShapeWithoutStyle(1, shape);
+			writeShapeWithoutStyle(1, shape, 1, 0);
 			bits.flush();
 			var shape_data = closeTMP(old);
 

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -500,10 +500,11 @@ class Writer {
 
 		var num_records = grad.data.length;
 
-		if(ver < 4) {
-			if(num_records > 8)
-				throw "Gradient supports at most 8 control points ("+num_records+" has bee given) when shape verison is lower than 4!";
-		} else if(num_records > 15)
+		//if(ver < 4) {
+		//	if(num_records > 8)
+		//		throw "Gradient supports at most 8 control points ("+num_records+" has been given) when shape version is lower than 4!";
+		//} else 
+		if(num_records > 15)
 			throw "Gradient supports at most 15 control points ("+num_records+" has been given) at shape version 4!";
 
 		bits.writeBits(2, spread_mode);

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -151,7 +151,7 @@ class Writer {
 
 			var sx = Tools.toFixed16(m.scale.x);
 			var sy = Tools.toFixed16(m.scale.y);
-			var nbits = signedMinBits([sx, sy]);
+			var nbits = Tools.minBits([sx, sy]) + 1;
 
 			bits.writeBits(5, nbits);
 			bits.writeBits(nbits, sx);
@@ -736,8 +736,8 @@ class Writer {
 					writeFillStyles(ver, data.newStyles.fillStyles);
 					writeLineStyles(ver, data.newStyles.lineStyles);
 
-					style_info.numFillStyles += data.newStyles.fillStyles.length;
-					style_info.numLineStyles += data.newStyles.lineStyles.length;
+					style_info.numFillStyles = data.newStyles.fillStyles.length;
+					style_info.numLineStyles = data.newStyles.lineStyles.length;
 					style_info.fillBits = Tools.minBits([style_info.numFillStyles]);
 					style_info.lineBits = Tools.minBits([style_info.numLineStyles]);
 

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -495,8 +495,8 @@ class Writer {
 			case IMReserved1:	2;
 			case IMReserved2:	3;
 		};
-		if(ver < 4 && (spread_mode != 0 || interpolation_mode != 0))
-			throw "Spread must be Pad and interpolation mode must be Normal RGB in gradient specification when shape version is lower than 4!";
+		//if(ver < 4 && (spread_mode != 0 || interpolation_mode != 0))
+		//	throw "Spread must be Pad and interpolation mode must be Normal RGB in gradient specification when shape version is lower than 4!";
 
 		var num_records = grad.data.length;
 

--- a/format/swf/Writer.hx
+++ b/format/swf/Writer.hx
@@ -60,8 +60,23 @@ class Writer {
 		writeEnd();
 	}
 
+	function signedMinBits(values: Array<Int>): Int {
+		var x: Int = 0;
+		var allZeroes = true;
+		for (v in values) {
+			if (v != 0) {
+				allZeroes = false;
+				break;
+			}
+		}
+		if (! allZeroes) {
+			x = Tools.minBits(values) + 1;
+		}
+		return x;
+	}
+
 	function writeRect(r) {
-		var nbits = Tools.minBits([r.left, r.right, r.top, r.bottom]) + 1;
+		var nbits = signedMinBits([r.left, r.right, r.top, r.bottom]);
 
 		bits.writeBits(5,nbits);
 		bits.writeBits(nbits,r.left);
@@ -136,7 +151,7 @@ class Writer {
 
 			var sx = Tools.toFixed16(m.scale.x);
 			var sy = Tools.toFixed16(m.scale.y);
-			var nbits = Tools.minBits([sx, sy]) + 1;
+			var nbits = signedMinBits([sx, sy]);
 
 			bits.writeBits(5, nbits);
 			bits.writeBits(nbits, sx);
@@ -150,7 +165,7 @@ class Writer {
 
 			var rs0 = Tools.toFixed16(m.rotate.rs0);
 			var rs1 = Tools.toFixed16(m.rotate.rs1);
-			var nbits = Tools.minBits([rs0, rs1]) + 1;
+			var nbits = signedMinBits([rs0, rs1]);
 
 			bits.writeBits(5, nbits);
 			bits.writeBits(nbits, rs0);
@@ -159,7 +174,7 @@ class Writer {
 		} else
 			bits.writeBit(false);
 
-		var nbits = Tools.minBits([m.translate.x, m.translate.y]) + 1;
+		var nbits = signedMinBits([m.translate.x, m.translate.y]);
 
 		bits.writeBits(5, nbits);
 		bits.writeBits(nbits, m.translate.x);
@@ -890,7 +905,7 @@ class Writer {
 				writeMorphGradients(ver, gradients);
 
 			case MFSRadialGradient(startMatrix, endMatrix, gradients):
-				o.writeByte(FillStyleTypeId.LinearGradient);
+				o.writeByte(FillStyleTypeId.RadialGradient);
 				writeMatrix(startMatrix);
 				writeMatrix(endMatrix);
 				writeMorphGradients(ver, gradients);


### PR DESCRIPTION
Three commits:

https://github.com/Herschel/format/commit/2b58581ed775f79b799a490b62cddcdfd24d4787 should really be two commits; one line of it fixes a Linear/Radial mixup that you mentioned, and the rest of it is a purely cosmetic fix for bitlength fields to better match Flash behaviour and therefore make real bugs easier to spot.  (If a bitfield is signed, set it to minBits+1, unless all values are zero, in which case set it to 0.  In particular, this makes matrices not have extra bits if translate.x and translate.y are set to zero.  It also clears up a handful of other differences that were making me wonder whether I was looking at bugs or harmless differences.)

https://github.com/Herschel/format/commit/b1b47b7de75b2d4f19af6eec98f6fcd81d221fb4 fixes a bug in readShape() where it usually didn't pick up the flags just after EdgeBounds because it was still reading bits from the EdgeBounds bytes.

https://github.com/Herschel/format/commit/cb931182f2fc2d92ad6ba4a77842149afca9a21f fixes a hardcode where fillBits and lineBits in writeShapeWithoutStyle were assumed to be 1.  It also has the reader store those numbers instead of discarding them for ShapeWithoutStyle, ShapeWithStyle, and SCRNewStyles.  I'm not sure if these are useful fixes or merely make the output match the original Flash output better.

The second commit on the list is a clear bug fix; the other ones I'm not so sure about.